### PR TITLE
JJOBS-8956 k8s 환경에서 네트워크 상태 반복 체크 후 기동 필요

### DIFF
--- a/build/shell/entrypoint.sh
+++ b/build/shell/entrypoint.sh
@@ -13,7 +13,7 @@ then
   sleep 1
   . $WORKING_DIR/after-install.sh
   sleep 1
-  . $WORKING_DIR/network-status-check.sh
+  . $WORKING_DIR/network-status-check.sh || true
 
   if [ "$ON_BOOT" == "yes" ] || [ "$ON_BOOT" == "y" ]; then
     if [ "$INSTALL_KIND" == "A" ]; then

--- a/build/shell/network-status-check.sh
+++ b/build/shell/network-status-check.sh
@@ -15,7 +15,7 @@ then
                 echo "Database connection is available."
                 break
             else
-                echo "Database connection failed. Retrying in 1 second..."
+                echo "Database connection failed. Retrying in 5 seconds..."
                 sleep 5
             fi
         done
@@ -33,7 +33,7 @@ then
                 echo "jjob-server is available."
                 break
             else
-                echo "jjob-server status check failed. Retrying in 1 second..."
+                echo "jjob-server status check failed. Retrying in 5 seconds..."
                 sleep 5
             fi
         done


### PR DESCRIPTION
- 네트워크 상태 확인 실패 시 재시도 주기 5초로 수정
- entrypoint에서 네트워크 상태 체크 구문은 오류시 즉시 종료 제외 처리