### PR TITLE
JJOBS-9392 J-Jobs 2.11.1 이미지 적용 작업

### DIFF
--- a/build/shell/after-install.sh
+++ b/build/shell/after-install.sh
@@ -64,10 +64,10 @@ tail -f $LOGS_BASE/server/$HOSTNAME/server.log@g' $JJOBS_BASE/start_server.sh
         fi
 
         echo "setting for java security.."
-        sed -i '307d' $JJOBS_BASE/jdk8u212-b03/jre/lib/security/java.security
-        sed -i '307inetworkaddress.cache.ttl=1' $JJOBS_BASE/jdk8u212-b03/jre/lib/security/java.security
-        sed -i '322d' $JJOBS_BASE/jdk8u212-b03/jre/lib/security/java.security
-        sed -i '322inetworkaddress.cache.negative.ttl=3' $JJOBS_BASE/jdk8u212-b03/jre/lib/security/java.security
+        sed -i '316d' $JJOBS_BASE/openjdk-8u342-b07-jre/lib/security/java.security
+        sed -i '316inetworkaddress.cache.ttl=1' $JJOBS_BASE/openjdk-8u342-b07-jre/lib/security/java.security
+        sed -i '331d' $JJOBS_BASE/openjdk-8u342-b07-jre/lib/security/java.security
+        sed -i '331inetworkaddress.cache.negative.ttl=3' $JJOBS_BASE/openjdk-8u342-b07-jre/lib/security/java.security
 fi
 
 if [ "$INSTALL_KIND" == "M" ] || [ "$INSTALL_KIND" == "F" ] ; then
@@ -119,10 +119,10 @@ if [ "$INSTALL_KIND" == "M" ] || [ "$INSTALL_KIND" == "F" ] ; then
         fi
 
         echo "setting for java security.."
-        sed -i '307d' $JJOBS_BASE/jdk8u212-b03/jre/lib/security/java.security
-        sed -i '307inetworkaddress.cache.ttl=1' $JJOBS_BASE/jdk8u212-b03/jre/lib/security/java.security
-        sed -i '322d' $JJOBS_BASE/jdk8u212-b03/jre/lib/security/java.security
-        sed -i '322inetworkaddress.cache.negative.ttl=3' $JJOBS_BASE/jdk8u212-b03/jre/lib/security/java.security
+        sed -i '316d' $JJOBS_BASE/openjdk-8u342-b07-jre/lib/security/java.security
+        sed -i '316inetworkaddress.cache.ttl=1' $JJOBS_BASE/openjdk-8u342-b07-jre/lib/security/java.security
+        sed -i '331d' $JJOBS_BASE/openjdk-8u342-b07-jre/lib/security/java.security
+        sed -i '331inetworkaddress.cache.negative.ttl=3' $JJOBS_BASE/openjdk-8u342-b07-jre/lib/security/java.security
 fi
 
 if [ "$WGET_URL" ] && [ "$WGET_FOLDER_PATH" ] && [ "$WGET_FILE_NAME" ] ; then

--- a/build/shell/network-status-check.sh
+++ b/build/shell/network-status-check.sh
@@ -9,9 +9,7 @@ then
     if [ "$ON_BOOT" == "yes" ] || [ "$ON_BOOT" == "y" ] || [ "$ON_BOOT" == "exceptagent" ]
     then
         while true; do
-            (echo quit | telnet $db_host $db_port) 2>&1 | grep -q "Connected to"
-
-            if [ $? -eq 0 ]; then
+            if timeout 3 bash -c "echo > /dev/tcp/$db_host/$db_port"; then
                 echo "Database connection is available."
                 break
             else


### PR DESCRIPTION
- 2.10 branch 분리(master: 2.11, production/2.10: 2.10)
- java security 설정에 2.11 JRE 경로 적용
- telnet freezing 현상으로 인해 네트웍 확인 구문 /dev/tcp로 변경