### PR TITLE
JJOBS-9092 Agent, runtime 기동 스크립트에 unset JAVA_TOOL_OPTIONS 추가

### DIFF
--- a/build/shell/entrypoint.sh
+++ b/build/shell/entrypoint.sh
@@ -15,23 +15,23 @@ then
 
   if [ "$ON_BOOT" == "yes" ] || [ "$ON_BOOT" == "y" ]; then
     if [ "$INSTALL_KIND" == "A" ]; then
-      . $JJOBS_BASE/start_agent.sh &
+      env -u JAVA_TOOL_OPTIONS bash -c ". $JJOBS_BASE/start_agent.sh" &
     elif [ "$INSTALL_KIND" == "S" ]; then
-      . $JJOBS_BASE/start_server.sh &
+      env -u JAVA_TOOL_OPTIONS bash -c ". $JJOBS_BASE/start_server.sh" &
     elif [ "$INSTALL_KIND" == "M" ]; then
-      . $JJOBS_BASE/start_manager.sh &
+      env -u JAVA_TOOL_OPTIONS bash -c ". $JJOBS_BASE/start_manager.sh" &
     else
       echo "start all..."
-      . $WORKING_DIR/start-all.sh
+      env -u JAVA_TOOL_OPTIONS bash -c ". $WORKING_DIR/start-all.sh" &
     fi
   elif [ "$ON_BOOT" == "manager" ]; then
     echo "start manager..."
-    . $JJOBS_BASE/start_manager.sh &
+    env -u JAVA_TOOL_OPTIONS bash -c ". $JJOBS_BASE/start_manager.sh" &
   elif [ "$ON_BOOT" == "exceptagent" ]; then
     echo "start manager and server..."
-    . $JJOBS_BASE/start_manager.sh &
+    env -u JAVA_TOOL_OPTIONS bash -c ". $JJOBS_BASE/start_manager.sh" &
     sleep 10
-    . $JJOBS_BASE/start_server.sh &
+    env -u JAVA_TOOL_OPTIONS bash -c ". $JJOBS_BASE/start_server.sh" &
   else
     echo "manual start..."
   fi


### PR DESCRIPTION
- J-Jobs Manager/Server/Agent 자원 기동 시 JAVA_TOOL_OPTIONS 환경 변수 무시하도록 구성