### PR TITLE
JJOBS-9510 컨테이너 버전 network status check 쉘 프로세스 분리

### DIFF
--- a/build/shell/entrypoint.sh
+++ b/build/shell/entrypoint.sh
@@ -13,7 +13,9 @@ then
   sleep 1
   . $WORKING_DIR/after-install.sh
   sleep 1
-  . $WORKING_DIR/network-status-check.sh || true
+  (
+    $WORKING_DIR/network-status-check.sh || true
+  )
 
   if [ "$ON_BOOT" == "yes" ] || [ "$ON_BOOT" == "y" ]; then
     if [ "$INSTALL_KIND" == "A" ]; then


### PR DESCRIPTION
- network status check가 실행중인지 확인하기 위해 entrypoint에서 별도 쉘 프로세스로 분리
- network status check 실행 여부에 따라 livenessProbe를 조정하기 위함