### PR TITLE
JJOBS-9511 컨테이너 환경 DNS 캐시 보안 설정 환경 변수 추가

### DIFF
--- a/build/shell/after-install.sh
+++ b/build/shell/after-install.sh
@@ -62,13 +62,19 @@ tail -f $LOGS_BASE/server/$HOSTNAME/server.log@g' $JJOBS_BASE/start_server.sh
         else
           sed -i '3iexport JJOB_SERVER_IP='"$HOSTNAME"'.'"$JJOB_SERVICE_NAME"'' $JJOBS_BASE/start_server.sh
         fi
-
-        echo "setting for java security.."
-        sed -i '316d' $JJOBS_BASE/openjdk-8u342-b07-jre/lib/security/java.security
-        sed -i '316inetworkaddress.cache.ttl=1' $JJOBS_BASE/openjdk-8u342-b07-jre/lib/security/java.security
-        sed -i '331d' $JJOBS_BASE/openjdk-8u342-b07-jre/lib/security/java.security
-        sed -i '331inetworkaddress.cache.negative.ttl=3' $JJOBS_BASE/openjdk-8u342-b07-jre/lib/security/java.security
 fi
+
+echo "setting for java security.."
+if [ -z "$NETWORKADDRESS_CACHE_TTL" ]; then
+  export NETWORKADDRESS_CACHE_TTL=1
+fi
+if [ -z "$NETWORKADDRESS_CACHE_NEGATIVE_TTL" ]; then
+  export NETWORKADDRESS_CACHE_NEGATIVE_TTL=3
+fi
+sed -i '313d' $JJOBS_BASE/openjdk-8u342-b07-jre/lib/security/java.security
+sed -i '313inetworkaddress.cache.ttl='"$NETWORKADDRESS_CACHE_TTL"'' $JJOBS_BASE/openjdk-8u342-b07-jre/lib/security/java.security
+sed -i '328d' $JJOBS_BASE/openjdk-8u342-b07-jre/lib/security/java.security
+sed -i '328inetworkaddress.cache.negative.ttl='"$NETWORKADDRESS_CACHE_NEGATIVE_TTL"'' $JJOBS_BASE/openjdk-8u342-b07-jre/lib/security/java.security
 
 if [ "$INSTALL_KIND" == "M" ] || [ "$INSTALL_KIND" == "F" ] ; then
         echo "unwar..."
@@ -117,12 +123,6 @@ if [ "$INSTALL_KIND" == "M" ] || [ "$INSTALL_KIND" == "F" ] ; then
         if [ -n "$SSO_KEYCLOAK_ISSUER_URI" ]; then
                 sed -i '3iexport SSO_KEYCLOAK_ISSUER_URI='$SSO_KEYCLOAK_ISSUER_URI'' start_manager.sh
         fi
-
-        echo "setting for java security.."
-        sed -i '316d' $JJOBS_BASE/openjdk-8u342-b07-jre/lib/security/java.security
-        sed -i '316inetworkaddress.cache.ttl=1' $JJOBS_BASE/openjdk-8u342-b07-jre/lib/security/java.security
-        sed -i '331d' $JJOBS_BASE/openjdk-8u342-b07-jre/lib/security/java.security
-        sed -i '331inetworkaddress.cache.negative.ttl=3' $JJOBS_BASE/openjdk-8u342-b07-jre/lib/security/java.security
 fi
 
 if [ "$WGET_URL" ] && [ "$WGET_FOLDER_PATH" ] && [ "$WGET_FILE_NAME" ] ; then

--- a/readme.md
+++ b/readme.md
@@ -23,30 +23,32 @@ J-Jobs의 매니저, 서버, 에이전트를 하나의 Pod 안에 설치하고 �
 초기 설치 시에는 `ON_BOOT` 설정을 'manual' 또는 'manager'로 설정하고, 설치가 종료된 이후에 'yes'로 변경하여 사용한다.
 해당 설정은 statefulset manifest의 환경 변수(`.spec.template.spec.containers[].env`)로 관리한다.
 
-| Key                  | Default value                          | Description                                                                                                                                                                                                    |
-|----------------------|----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| INSTALL_KIND         | F                                      | J-Jobs 설치 유형<br/> - F : 전체 설치<br/>- M : Manager 단독 설치<br/>- S : Server 단독 설치<br/>- A : Agent 단독 설치                                                                                                             |
-| ON_BOOT              | yes (or y)                                   | 설치 & 구동 관련 옵션<br/> -yes (or y) : 설치 후 모두 기동<br/>- manual : 설치 후 기동은 Pod에 접속하여 직접 수행(초기 설치 시 사용)<br/>- manager : 설치 후 매니저만 기동(초기 설치 시 사용)<br/>- no (기타) : 설치 및 기동 모두 하지 않음 <br/>- exceptagent : 에이전트 제외한 매니저, 서버 기동 |
-| MANAGER_WEB_PORT     | 7065                                   | J-Jobs 매니저 web(was) port                                                                                                                                                                                       |
-| SERVER_WEB_PORT      | 7075                                   | J-Jobs 서버 web(was) port                                                                                                                                                                                        |
-| SERVER_TCP_PORT      | 17075                                  | J-Job 서버와 에이전트 간의 통신을 위한 TCP Port                                                                                                                                                                              |
-| DB_TYPE              | postgres                               | J-Jobs의 Meta DB 유형<br/>-postgres<br/>-oracle<br/>-mysql<br/>mariadb                                                                                                                                            |
-| JDBC_URL             | jdbc:postgresql://127.0.0.1:7432/jjobs | DB 접속 JDBC URL 설정                                                                                                                                                                                              |
-| USE_DB_ENCRYPT       | N                                  | 	DB 사용자명, 패스워드 암호화 사용 여부 사용자명                                                                                                                                                                                  |
-| DB_USER              | jjobs                                  | 	JDBC URL로 DB에 접속할 때 사용자명                                                                                                                                                                                      |
-| DB_PASSWD	           | jjobs1234                              | JDBC URL로 DB에 접속할 때 패스워드                                                                                                                                                                                       |
-| ENCRYPTED_DB_USER    | oSAv48QO9j6VAy7mT8YYbA==                                  | 	JDBC URL로 DB에 접속할 때 사용자명<br/>USE_DB_ENCRTPY가 Y 일 때 사용                                                                                                                                                         |
-| ENCRYPTED_DB_PASSWD	 | v3bY7QfdJPzTEuxcVWlq3w==                              | JDBC URL로 DB에 접속할 때 패스워드<br/>USE_DB_ENCRTPY가 Y 일 때 사용                                                                                                                                                          |
-| JJOB_SERVICE_NAME    | jjobs.default.svc.cluster.local        | 전체 설치/서버 설치 시 사용<br/>(start_server.sh 에서 JJOB_SERVER_IP 환경 변수로 "StatefulSet으로 생성된 pod의 hostname + JJOB_SERVICE_NAME"를 추가함)<br/><br/>(예시)<br/>export JJOB_SERVER_IP=jjobs-0.jjobs.default.svc.cluster.local     |
-| AGENT_GROUP_ID       | 0                                      | 	에이전트 그룹 ID 설정                                                                                                                                                                                                 |
+| Key                  | Default value                          | Description                                                                                                                                                                                                            |
+|----------------------|----------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| INSTALL_KIND         | F                                      | J-Jobs 설치 유형<br/> - F : 전체 설치<br/>- M : Manager 단독 설치<br/>- S : Server 단독 설치<br/>- A : Agent 단독 설치                                                                                                                     |
+| ON_BOOT              | yes (or y)                             | 설치 & 구동 관련 옵션<br/> -yes (or y) : 설치 후 모두 기동<br/>- manual : 설치 후 기동은 Pod에 접속하여 직접 수행(초기 설치 시 사용)<br/>- manager : 설치 후 매니저만 기동(초기 설치 시 사용)<br/>- no (기타) : 설치 및 기동 모두 하지 않음 <br/>- exceptagent : 에이전트 제외한 매니저, 서버 기동     |
+| MANAGER_WEB_PORT     | 7065                                   | J-Jobs 매니저 web(was) port                                                                                                                                                                                               |
+| SERVER_WEB_PORT      | 7075                                   | J-Jobs 서버 web(was) port                                                                                                                                                                                                |
+| SERVER_TCP_PORT      | 17075                                  | J-Job 서버와 에이전트 간의 통신을 위한 TCP Port                                                                                                                                                                                      |
+| DB_TYPE              | postgres                               | J-Jobs의 Meta DB 유형<br/>-postgres<br/>-oracle<br/>-mysql<br/>mariadb                                                                                                                                                    |
+| JDBC_URL             | jdbc:postgresql://127.0.0.1:7432/jjobs | DB 접속 JDBC URL 설정                                                                                                                                                                                                      |
+| USE_DB_ENCRYPT       | N                                      | 	DB 사용자명, 패스워드 암호화 사용 여부 사용자명                                                                                                                                                                                          |
+| DB_USER              | jjobs                                  | 	JDBC URL로 DB에 접속할 때 사용자명                                                                                                                                                                                              |
+| DB_PASSWD	           | jjobs1234                              | JDBC URL로 DB에 접속할 때 패스워드                                                                                                                                                                                               |
+| ENCRYPTED_DB_USER    | oSAv48QO9j6VAy7mT8YYbA==               | 	JDBC URL로 DB에 접속할 때 사용자명<br/>USE_DB_ENCRTPY가 Y 일 때 사용                                                                                                                                                                 |
+| ENCRYPTED_DB_PASSWD	 | v3bY7QfdJPzTEuxcVWlq3w==               | JDBC URL로 DB에 접속할 때 패스워드<br/>USE_DB_ENCRTPY가 Y 일 때 사용                                                                                                                                                                  |
+| JJOB_SERVICE_NAME    | jjobs.default.svc.cluster.local        | 전체 설치/서버 설치 시 사용<br/>(start_server.sh 에서 JJOB_SERVER_IP 환경 변수로 "StatefulSet으로 생성된 pod의 hostname + JJOB_SERVICE_NAME"를 추가함)<br/><br/>(예시)<br/>export JJOB_SERVER_IP=jjobs-0.jjobs.default.svc.cluster.local             |
+| AGENT_GROUP_ID       | 0                                      | 	에이전트 그룹 ID 설정                                                                                                                                                                                                         |
 | LOGS_BASE	         | /logs001/jjobs	                        | (에이전트 설정) 로그 경로                                                                                                                                                                                                        |
-| LOG_KEEP_DATE	       | 5                                      | 	(에이전트 설정) 로그 유지 일수                                                                                                                                                                                            |
-| LOG_DELETE_YN        | 	Y                                     | (에이전트 설정) 로그 백업 옵션<br/>-Y : 삭제<br/>-N : 백업<br/>-Z : 백업/압축                                                                                                                                                      |
-| JJOBS_SERVER_IP      | 	127.0.0.1                             | 에이전트가 서버에 접근하기 위한 서버의 서비스 IP<br/><br/>(예시)<br/>start_agent.sh에 들어가는 서버 IP(JJOBS_SERVER_IP)는 서비스 명을 사용해도 됨 → jjobs.default.svc.cluster.local                                                                    |
+| LOG_KEEP_DATE	       | 5                                      | 	(에이전트 설정) 로그 유지 일수                                                                                                                                                                                                    |
+| LOG_DELETE_YN        | 	Y                                     | (에이전트 설정) 로그 백업 옵션<br/>-Y : 삭제<br/>-N : 백업<br/>-Z : 백업/압축                                                                                                                                                              |
+| JJOBS_SERVER_IP      | 	127.0.0.1                             | 에이전트가 서버에 접근하기 위한 서버의 서비스 IP<br/><br/>(예시)<br/>start_agent.sh에 들어가는 서버 IP(JJOBS_SERVER_IP)는 서비스 명을 사용해도 됨 → jjobs.default.svc.cluster.local                                                                            |
+| NETWORKADDRESS_CACHE_TTL      | 	1                                     | Java의 DNS positive cache (정상적으로 조회된 DNS)의 TTL(Time To Live) 설정                                                                                                                                                        |
+| NETWORKADDRESS_CACHE_NEGATIVE_TTL      | 	3                                     | Java의 DNS negative cache (실패한 DNS 조회)의 TTL(Time To Live) 설정                                                                                                                                                                    |
 | API_PRIVATE_TOKEN    |                                        | `preStop`, `postStart` 훅에 사용할 J-Jobs 사용자의 비밀 토큰 (예시) 26da841583291d1b6ef7                                                                                                                                              |
 | WGET_URL |                                        | 추가 APP 설치 필요 시 다운로드 URL<br/>zip, tar.gz, tar 형식의 경우 다운로드 후 WGET_FOLDER_PATH 경로에 압축 해제함<br/>(예시) https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-x64_bin.tar.gz |
 | WGET_FOLDER_PATH |                                        | 추가 APP 설치 필요 시 설치 경로 (예시) /home/jjobs/jdk-test                                                                                                                                                                         |
-| WGET_FILE_NAME |                                        | 추가 APP 다운로드 파일명 (예시) jdk17.tar.gz                                                                                                                                                                                                  |
+| WGET_FILE_NAME |                                        | 추가 APP 다운로드 파일명 (예시) jdk17.tar.gz                                                                                                                                                                                      |
 
 #### Graceful shutdown 설정
 재기동, 버전 업그레이드 등으로 pod의 종료/기동이 필요한 경우 Job 실행 정보의 정합성 유지를 위해 jjob-server와 Agent 종료 이후 pod를 종료하는 것을 권장한다.
@@ -123,6 +125,10 @@ spec:
               value: "10"
             - name: LOG_DELETE_YN
               value: "Y"
+            - name: NETWORKADDRESS_CACHE_TTL
+              value: "1"
+            - name: NETWORKADDRESS_CACHE_NEGATIVE_TTL
+              value: "3"
             - name: ON_BOOT
               value: "exceptagent"
             - name: INSTALL_KIND
@@ -328,6 +334,10 @@ spec:
           value: "yes"
         - name: INSTALL_KIND
           value: "A"
+        - name: NETWORKADDRESS_CACHE_TTL
+          value: "1"
+        - name: NETWORKADDRESS_CACHE_NEGATIVE_TTL
+          value: "3"
         - name: LANG
           value: ko_KR.utf8
         #- name: API_PRIVATE_TOKEN

--- a/templates/jjobs-agent-statefulset.yaml
+++ b/templates/jjobs-agent-statefulset.yaml
@@ -53,6 +53,10 @@ spec:
               value: "yes"
             - name: INSTALL_KIND
               value: "A"
+            - name: NETWORKADDRESS_CACHE_TTL
+              value: "1"
+            - name: NETWORKADDRESS_CACHE_NEGATIVE_TTL
+              value: "3"
             - name: LANG
               value: ko_KR.utf8
             - name: API_PRIVATE_TOKEN

--- a/templates/jjobs-statefulset.yaml
+++ b/templates/jjobs-statefulset.yaml
@@ -57,6 +57,10 @@ spec:
               value: "10"
             - name: LOG_DELETE_YN
               value: "Y"
+            - name: NETWORKADDRESS_CACHE_TTL
+              value: "1"
+            - name: NETWORKADDRESS_CACHE_NEGATIVE_TTL
+              value: "3"
             - name: ON_BOOT
               value: "exceptagent"
             - name: INSTALL_KIND


### PR DESCRIPTION
- networkaddress.cache.ttl, networkaddress.cache.negative.ttl 환경 변수를 추가하며, 미입력 시 기본값은 1, 3으로 한다.