### PR TITLE
JJOBS-10168 컨테이너 버전 표준 출력으로 매니저, 에이전트, 런타임 로그 추가

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -118,6 +118,7 @@ COPY shell/agent-healthcheck.sh $WORKING_DIR/
 COPY shell/network-status-check.sh $WORKING_DIR/
 COPY shell/readiness.sh $WORKING_DIR/
 COPY shell/liveness.sh $WORKING_DIR/
+COPY shell/tail-agent-syslog.sh $WORKING_DIR/
 COPY installer/jjob_installer_linux_x64.sh /install/
 
 RUN chmod ug+x $WORKING_DIR/*.sh \


### PR DESCRIPTION
- tail-agent-syslog.sh 파일 빌드 대상으로 추가