### PR TITLE
JJOBS-10226 J-Jobs for Container Docker image Amazon linux 2022 지원 종료 대응

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -68,7 +68,7 @@ RUN dnf update -y && dnf clean all \
     jq \
     bind-utils \
     passwd \
-    vim
+    vim vim-minimal
 #RUN mkdir /var/run/sshd
 #RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
 
@@ -126,7 +126,10 @@ RUN chmod ug+x $WORKING_DIR/*.sh \
     && chmod ug+x /*.sh
 #RUN chown -R jjobs:jjobs $WORKING_DIR
 #RUN chown jjobs:jjobs /entrypoint.sh
-RUN echo 'if [ -f /etc/bashrc ]; then . /etc/bashrc; fi' >> /root/.bashrc
+# System-wide aliases (applies to root and any future user via /etc/skel/.bashrc)
+COPY shell/jjobs-aliases.sh /etc/profile.d/jjobs-aliases.sh
+RUN chmod 644 /etc/profile.d/jjobs-aliases.sh \
+    && echo 'if [ -f /etc/bashrc ]; then . /etc/bashrc; fi' >> /root/.bashrc
 
 VOLUME ["/logs001/jjobs"]
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@
 
 # Pull base image
 # ---------------
-FROM public.ecr.aws/amazonlinux/amazonlinux:2022 as base
+FROM amazonlinux:2023 as base
 
 # Maintainer
 # ----------
@@ -53,8 +53,8 @@ ENV ON_BOOT=yes \
 
 # Install Util
 # -------------------------------------------------------------
-RUN yum update; yum clean all \
-    && yum -y install wget \
+RUN dnf update -y && dnf clean all \
+    && dnf -y install wget \
     openssh-server openssh-clients \
     hostname \
     tar \
@@ -66,7 +66,7 @@ RUN yum update; yum clean all \
     fontconfig \
     #iptables \
     jq \
-    dnsutils \
+    bind-utils \
     passwd \
     vim
 #RUN mkdir /var/run/sshd

--- a/build/batch-sample/Dockerfile
+++ b/build/batch-sample/Dockerfile
@@ -4,7 +4,7 @@
 
 # Pull base image
 # ---------------
-FROM public.ecr.aws/amazonlinux/amazonlinux:2022 as base
+FROM amazonlinux:2023 as base
 
 # Maintainer
 # ----------
@@ -19,8 +19,8 @@ ENV WORKING_DIR=/working
 
 # Install Util
 # -------------------------------------------------------------
-RUN yum update; yum clean all \
-    && yum -y install openssh-server openssh-clients \
+RUN dnf update -y && dnf clean all \
+    && dnf -y install openssh-server openssh-clients \
     hostname \
     tar \
     ncurses \

--- a/build/shell/jjobs-aliases.sh
+++ b/build/shell/jjobs-aliases.sh
@@ -1,0 +1,5 @@
+# System-wide shell aliases for J-Jobs container.
+# Loaded automatically by /etc/bashrc for all interactive shells.
+alias ll='ls -l --color=auto'
+alias la='ls -al --color=auto'
+alias l.='ls -d .* --color=auto'

--- a/build/shell/liveness.sh
+++ b/build/shell/liveness.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #install kind: M && ON_BOOT: yes or y or exeptagent  => Manager check
 #install kind: S && ON_BOOT: yes or y or exeptagent && RESUME_ON_STARTUP: y or yes => Server check
 #install kind: A && ON_BOOT: yes or y => Agent check

--- a/build/shell/post-start.sh
+++ b/build/shell/post-start.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #install kind: M => Do nothing
 #install kind: S && ON_BOOT: yes or y or exeptagent && RESUME_ON_STARTUP: y or yes => Server resume
 #install kind: A && ON_BOOT: yes or y && RESUME_ON_STARTUP: y or yes => Agent resume

--- a/build/shell/pre-stop.sh
+++ b/build/shell/pre-stop.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #install kind: M => Do nothing
 #install kind: S && ON_BOOT: yes or y or exeptagent => Server gracefully stop
 #install kind: A && ON_BOOT: yes or y =>  Agent gracefully stop

--- a/build/shell/readiness.sh
+++ b/build/shell/readiness.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #install kind: M && ON_BOOT: yes or y or exeptagent  => Manager check
 #install kind: S && ON_BOOT: yes or y or exeptagent && RESUME_ON_STARTUP: y or yes => Server check
 #install kind: A && ON_BOOT: yes or y => Agent check

--- a/build/spring-batch-sample/Dockerfile
+++ b/build/spring-batch-sample/Dockerfile
@@ -4,8 +4,8 @@
 
 # Pull base image
 # ---------------
-#FROM public.ecr.aws/amazonlinux/amazonlinux:2022 as base
-FROM amazoncorretto:8
+#FROM amazonlinux:2023 as base
+FROM amazoncorretto:8-al2023
 
 # Maintainer
 # ----------
@@ -20,7 +20,7 @@ ENV WORKING_DIR=/working
 
 # Install Util
 # -------------------------------------------------------------
-RUN yum update; yum clean all    
+RUN dnf update -y && dnf clean all
 
 
 # Copy files needed during both installation and runtime


### PR DESCRIPTION
- 모든 Dockerfile (build/, build/batch-sample/, build/spring-batch-sample/)의 베이스 이미지 amazonlinux:2022 -> amazonlinux:2023로 업데이트
- yum 명령어 dnf로 변경(AL2023 표준)
- `dnsutils` 패키지 `bind-utils`로 교체(동일 기능)