### PR TITLE
JJOBS-10717 컨테이너 종료 시 SIGTERM 미처리로 terminationGracePeriodSeconds 만료까지Pod 종료/재기동이 지연되는 문제

### DIFF
--- a/build/shell/entrypoint.sh
+++ b/build/shell/entrypoint.sh
@@ -50,8 +50,13 @@ fi
 
 ##
 ## Workaround for graceful shutdown.
+## kubelet의 SIGTERM 수신시에만 루프를 탈출하여 PID 1을 정상 종료.
 ##
-while [ "$END" == '' ]; do
-        sleep 5
+JJOBS_SIGTERM_RECEIVED=''
+trap 'JJOBS_SIGTERM_RECEIVED=1' TERM
+while [ -z "$JJOBS_SIGTERM_RECEIVED" ]; do
+        sleep 5 &
+        wait $! || true
 done
-;;
+
+exit 0;


### PR DESCRIPTION
 - trap 미설정 시 PID 1(bash)은 SIGTERM을 무시하므로 preStop 완료 후에도 terminationGracePeriodSeconds 만료(SIGKILL)까지 컨테이너가 종료되지 않는 문제 발생
 - 명시적 초기화로 외부 env/source 스크립트에 의한 변수 오염 차단
 - sleep을 백그라운드로 돌리고 wait하여 SIGTERM 수신 즉시 루프 탈출